### PR TITLE
Increase start timeout to 6 minutes

### DIFF
--- a/ocf/serviced
+++ b/ocf/serviced
@@ -102,7 +102,7 @@ The pid file to use for this Control Center (serviced) instance
 </parameters>
 
 <actions>
-<action name="start" timeout="60" />
+<action name="start" timeout="360" />
 <action name="stop" timeout="90" />
 <action name="status" timeout="20" />
 <action name="monitor" timeout="30" interval="30" />


### PR DESCRIPTION
Fixes CC-1413

Increase start timeout to 6 minutes to allow 2 minutes beyond the 4 minute isvc timeout