### PR TITLE
Add targets to build RPM and DEB packages using a docker container

### DIFF
--- a/makefile
+++ b/makefile
@@ -44,16 +44,20 @@ export DESCRIPTION
 .PHONY: all clean deb rpm test
 .SILENT: usage
 
-all:
+all: docker-rpm docker-deb
+
+docker-rpm:
 	docker build -t zenoss/serviced-resource-agents:rpm-$(PKG_VERSION) ./pkg/rpm
 	docker run --rm -v `pwd`:/serviced-resource-agents zenoss/serviced-resource-agents:rpm-$(PKG_VERSION)
+
+docker-deb:
 	docker build -t zenoss/serviced-resource-agents:deb-$(PKG_VERSION) ./pkg/deb
 	docker run --rm -v `pwd`:/serviced-resource-agents zenoss/serviced-resource-agents:deb-$(PKG_VERSION)
 
 usage:
 	echo "Usage: make deb or make rpm.  Both options package $(FULL_NAME)-$(PKG_VERSION)."
 
-test: 
+test:
 	sudo ocf-tester -n serviced -o config=$(TEST_CONFIG) -o ipaddr=172.17.42.1 -o binary=`which serviced` ocf/serviced
 
 .PHONY: clean_files


### PR DESCRIPTION
Turns out the newer build boxes created in Dec 2015 don't necessarily have the ruby stack we need to run `fpm`, so this adjustment allows us to build just the RPM package using the docker image already defined in this repo.