### PR TITLE
correct regex usage for unmounting /opt/serviced/var/volumes/*

### DIFF
--- a/ocf/serviced-storage
+++ b/ocf/serviced-storage
@@ -135,7 +135,7 @@ unmount_all_tenant_volumes() {
     # For scenarios where serviced failed to shtudown completely, there may be
     # dangling devicemapper mounts as well. These need to be unmounted so that
     # the devicemapper devices can be completed deactivated.
-    TENANT_MOUNTS=`grep /opt/serviced/var/volumes/[a-zA-Z0-9]* /proc/mounts | cut -d' ' -f2`
+    TENANT_MOUNTS=`grep '/opt/serviced/var/volumes/[a-zA-Z0-9]*' /proc/mounts | cut -d' ' -f2`
     for volume in $TENANT_MOUNTS; do
         ocf_log info "Unmounting $volume"
         ocf_run umount -f $volume || exit $OCF_ERR_GENERIC


### PR DESCRIPTION
In cases where serviced was stopped with `kill -s 9` the script needs to unmount any UUID directories it finds in /opt/serviced/var/volumes. This change fixes a quoting issue in the regex used to identify any of those directories.