### PR TITLE
Adjust stop time to match changes in CC-1707

### DIFF
--- a/ocf/serviced
+++ b/ocf/serviced
@@ -103,7 +103,7 @@ The pid file to use for this Control Center (serviced) instance
 
 <actions>
 <action name="start" timeout="360" />
-<action name="stop" timeout="90" />
+<action name="stop" timeout="130" />
 <action name="status" timeout="20" />
 <action name="monitor" timeout="30" interval="30" />
 <action name="validate-all" timeout="5" />


### PR DESCRIPTION
CC-1707 increased the service stop time to 120 seconds

This change increases the stop time for the HA resource agent to just a little more, 130 seconds.