### PR TITLE
Sign the resource agent rpm

### DIFF
--- a/makefile
+++ b/makefile
@@ -50,6 +50,7 @@ all: docker-rpm docker-deb
 docker-rpm:
 	docker build -t zenoss/serviced-resource-agents:rpm-$(PKG_VERSION) ./pkg/rpm
 	docker run --rm --user $(DUID):$(DGID) -v `pwd`:/serviced-resource-agents zenoss/serviced-resource-agents:rpm-$(PKG_VERSION)
+	./sign-rpm.sh
 
 docker-deb:
 	docker build -t zenoss/serviced-resource-agents:deb-$(PKG_VERSION) ./pkg/deb

--- a/sign-rpm.sh
+++ b/sign-rpm.sh
@@ -1,0 +1,16 @@
+# Signs the resource agent RPM with the Zenoss signature.
+
+export HOST_RPM_LOC=$(pwd)
+echo "RPM Folder is ${HOST_RPM_LOC}"
+
+echo "Cloning the mkyum repo.."
+git clone git@github.com:zenoss/mkyum.git --branch master --single-branch $HOST_RPM_LOC/mkyum
+
+echo "Building the mkyum image.."
+cd mkyum
+make mkyum-build
+
+echo "Signing the resource agent rpm.."
+cd mkrepo
+make sign-rpms
+


### PR DESCRIPTION
https://jira.zenoss.com/browse/BLD-176
The resource agents rpm that gets put on artifacts isn't signed, and that's being put on leapfile.  We'll sign it when the rpm is created so that all copies are GPG signed.